### PR TITLE
Add comprehensive documentation to all public APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ Gemfile.lock
 .bundle
 *.gem
 /node_modules
+/doc
 
 spec/examples.txt

--- a/.rdoc_options
+++ b/.rdoc_options
@@ -1,0 +1,7 @@
+---
+encoding: UTF-8
+main_page: README.md
+title: "Fino - Dynamic Settings Engine for Ruby and Rails"
+markup: rdoc
+line_numbers: false
+tab_width: 2

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,29 @@
 # frozen_string_literal: true
 
 require "fino/version"
+require "rdoc/task"
 
 ARTIFACTS_FOLDER = "artifacts"
+
+RDoc::Task.new(:rdoc) do |rdoc|
+  rdoc.rdoc_dir = "doc"
+  rdoc.title = "Fino #{Fino::VERSION}"
+  rdoc.main = "README.md"
+  rdoc.rdoc_files.include("README.md", "lib/**/*.rb")
+  rdoc.rdoc_files.exclude(
+    "lib/fino-rails.rb",
+    "lib/fino-redis.rb",
+    "lib/fino-solid.rb",
+    "lib/fino/rails.rb",
+    "lib/fino/rails/**/*",
+    "lib/fino/redis.rb",
+    "lib/fino/redis/**/*",
+    "lib/fino/solid.rb",
+    "lib/fino/solid/**/*",
+    "lib/fino/metadata.rb",
+    "lib/fino/railtie.rb"
+  )
+end
 
 desc "Build all gems into the artifacts directory"
 task :build do

--- a/lib/fino.rb
+++ b/lib/fino.rb
@@ -3,39 +3,131 @@
 require "forwardable"
 require "zeitwerk"
 
+# Fino is a dynamic settings engine for Ruby and Rails.
+#
+# It provides a DSL for defining typed settings (string, integer, float, boolean),
+# organized into optional sections, with support for scoped overrides, A/B testing
+# variants, and unit conversion for numeric values.
+#
+# All settings access methods are delegated to Fino::Library, making the +Fino+
+# module the primary public interface.
+#
+# == Quick Start
+#
+#   require "fino-redis"
+#
+#   Fino.configure do
+#     adapter { Fino::Redis::Adapter.new(Redis.new) }
+#     cache { Fino::Cache::Memory.new(expires_in: 3) }
+#
+#     settings do
+#       setting :maintenance_mode, :boolean, default: false
+#
+#       section :openai, label: "OpenAI" do
+#         setting :model, :string, default: "gpt-5"
+#         setting :temperature, :float, default: 0.7
+#       end
+#     end
+#   end
+#
+#   Fino.value(:model, at: :openai)        #=> "gpt-5"
+#   Fino.enabled?(:maintenance_mode)       #=> false
+#   Fino.set(model: "gpt-6", at: :openai)
+#
+# == Architecture
+#
+# Fino uses a pipeline architecture with composable pipes for reading and writing
+# settings. A storage adapter (e.g. Redis) persists values, and an optional cache
+# layer reduces round-trips. See Fino::Pipeline, Fino::Adapter, and Fino::Cache.
 module Fino
+  # Manages lifecycle of Fino's core objects (library, registry, configuration).
+  #
+  # Extended into the Fino module to provide top-level +configure+, +reset!+,
+  # and +reconfigure+ methods.
   module Stateful
+    # Evaluates the given block in the context of Fino::Configuration.
+    #
+    # This is the primary entry point for setting up Fino. The block receives
+    # the configuration DSL including +adapter+, +cache+, +settings+, and +pipeline+.
+    #
+    #   Fino.configure do
+    #     adapter { MyAdapter.new }
+    #     settings do
+    #       setting :timeout, :integer, default: 30
+    #     end
+    #   end
     def configure(&)
       configuration.instance_eval(&)
     end
 
+    # Resets all internal state, discarding the current library, registry,
+    # and configuration. Subsequent calls will create fresh instances.
     def reset!
       @library = nil
       @registry = nil
       @configuration = nil
     end
 
+    # Resets all state and re-evaluates the configuration block.
+    # Equivalent to calling +reset!+ followed by +configure+.
     def reconfigure(&)
       reset!
       configure(&)
     end
 
+    # Returns the current Fino::Library instance, creating one if needed.
+    #
+    # The library is the main engine that handles reading and writing settings
+    # through the configured pipeline.
     def library
       @library ||= Fino::Library.new(configuration)
     end
 
+    # Returns the current Fino::Registry instance, creating one if needed.
+    #
+    # The registry holds all setting and section definitions.
     def registry
       @registry ||= Fino::Registry.new
     end
 
+    # Returns the current Fino::Configuration instance, creating one if needed.
     def configuration
       @configuration ||= Fino::Configuration.new(registry)
     end
   end
 
+  # Provides delegated access to Fino::Library settings methods.
+  #
+  # All public settings operations (+value+, +set+, +enabled?+, etc.) are
+  # forwarded to the +library+ instance. Any class or module that includes
+  # this module and implements +library+ gains the full settings API.
+  #
+  # See Fino::Library for detailed documentation of each method.
   module SettingsAccessible
     extend Forwardable
 
+    # @!method value(setting_name, at: nil, **context)
+    #   Returns the value of a single setting. See Fino::Library#value.
+    # @!method values(*setting_names, at: nil, **context)
+    #   Returns values of multiple settings. See Fino::Library#values.
+    # @!method enabled?(setting_name, at: nil, **context)
+    #   Returns +true+ if a boolean setting is enabled. See Fino::Library#enabled?.
+    # @!method disabled?(setting_name, at: nil, **context)
+    #   Returns +true+ if a boolean setting is disabled. See Fino::Library#disabled?.
+    # @!method enable(setting_name, at: nil, for: nil)
+    #   Enables a boolean setting globally or for a scope. See Fino::Library#enable.
+    # @!method disable(setting_name, at: nil, for: nil)
+    #   Disables a boolean setting globally or for a scope. See Fino::Library#disable.
+    # @!method setting(setting_name, at: nil)
+    #   Returns a Setting object for a single setting. See Fino::Library#setting.
+    # @!method settings(*setting_names, at: nil)
+    #   Returns Setting objects for multiple settings. See Fino::Library#settings.
+    # @!method slice(*settings)
+    #   Preloads specific settings in a single adapter call. See Fino::Library#slice.
+    # @!method set(**data)
+    #   Persists a setting value with optional overrides and variants. See Fino::Library#set.
+    # @!method add_override(setting_name, at: nil, **overrides)
+    #   Adds scope overrides to an existing setting. See Fino::Library#add_override.
     def_delegators :library,
                    :value,
                    :values,
@@ -57,10 +149,16 @@ module Fino
   extend SettingsAccessible
   extend Stateful
 
+  # Sentinel object used internally to distinguish "no argument provided"
+  # from an explicit +nil+.
   EMPTINESS = Object.new.freeze
 
   module_function
 
+  # Returns the logger used by Fino for debug and diagnostic output.
+  #
+  # Defaults to a +Logger+ writing to +$stdout+ at the level specified by
+  # the +FINO_LOG_LEVEL+ environment variable (default: +"info"+).
   def logger
     @logger ||= begin
       require "logger"
@@ -75,6 +173,7 @@ module Fino
     end
   end
 
+  # Returns the root path of the Fino gem installation.
   def root
     File.expand_path("..", __dir__)
   end

--- a/lib/fino/ab_testing/variant.rb
+++ b/lib/fino/ab_testing/variant.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
+# Represents a single variant in an A/B testing experiment.
+#
+# Each variant has a percentage (traffic allocation) and a value. The
+# special CONTROL_VALUE sentinel indicates the control group, which uses
+# the setting's global value.
 class Fino::AbTesting::Variant
+  # Sentinel value representing the control group. When a scope is assigned
+  # to the control variant, the setting's global value is used instead.
   CONTROL_VALUE = Class.new do
     def inspect
       "Fino::AbTesting::Variant::CONTROL_VALUE"
@@ -9,7 +16,14 @@ class Fino::AbTesting::Variant
 
   include Fino::PrettyInspectable
 
-  attr_reader :id, :percentage, :value
+  # Returns the unique identifier (UUID) for this variant.
+  attr_reader :id
+
+  # Returns the percentage of traffic allocated to this variant (0.0-100.0).
+  attr_reader :percentage
+
+  # Returns the variant value, or CONTROL_VALUE for the control group.
+  attr_reader :value
 
   def initialize(percentage:, value:)
     @id = SecureRandom.uuid

--- a/lib/fino/ab_testing/variant_picker.rb
+++ b/lib/fino/ab_testing/variant_picker.rb
@@ -2,15 +2,28 @@
 
 require "zlib"
 
+# Deterministically assigns a scope to a variant based on CRC32 hashing.
+#
+# The picker uses +Zlib.crc32+ on the concatenation of the setting key and
+# scope to produce a stable hash. This ensures the same scope always receives
+# the same variant (sticky assignment), without needing to store assignments.
 class Fino::AbTesting::VariantPicker
+  # Precision multiplier for percentage-based bucketing.
   SCALING_FACTOR = 1_000
 
+  # Returns the Fino::Definition::Setting used to generate the hash key.
   attr_reader :setting_definition
 
   def initialize(setting_definition)
     @setting_definition = setting_definition
   end
 
+  # Picks a variant for the given scope.
+  #
+  # +variants+ - Array of Fino::AbTesting::Variant instances (sorted by percentage).
+  # +scope+ - A scope identifier (e.g. user ID string).
+  #
+  # Returns the selected Fino::AbTesting::Variant, or +nil+ if variants is empty.
   def call(variants, scope)
     return nil if variants.empty?
 

--- a/lib/fino/adapter.rb
+++ b/lib/fino/adapter.rb
@@ -1,30 +1,78 @@
 # frozen_string_literal: true
 
+# Abstract interface for storage adapters.
+#
+# Implementations must include this module and define all methods to provide
+# persistence for setting values, overrides, and A/B testing variants.
+#
+# == Built-in Implementations
+#
+# - +Fino::Redis::Adapter+ -- Redis-backed storage (in the +fino-redis+ gem)
+# - +Fino::Solid::Adapter+ -- Database-backed storage via Rails (in the +fino-solid+ gem)
+#
+# == Implementing a Custom Adapter
+#
+#   class MyAdapter
+#     include Fino::Adapter
+#
+#     def read(setting_key)
+#       # Return raw data hash for the setting, or nil
+#     end
+#
+#     def read_multi(setting_keys)
+#       # Return array of raw data hashes (one per key)
+#     end
+#
+#     def write(setting_definition, value, overrides, variants)
+#       # Persist the setting
+#     end
+#     # ...
+#   end
 module Fino::Adapter
+  # Reads raw data for a single setting from storage.
+  #
+  # +setting_key+ - String key (e.g. +"openai/model"+).
+  #
+  # Returns a Hash of raw adapter data, or +nil+ if not persisted.
   def read(setting_key)
     raise NotImplementedError
   end
 
+  # Reads raw data for multiple settings from storage.
+  #
+  # +setting_keys+ - Array of String keys.
+  #
+  # Returns an Array of raw data Hashes (one per key).
   def read_multi(setting_keys)
     raise NotImplementedError
   end
 
+  # Persists a setting with its value, overrides, and variants.
+  #
+  # +setting_definition+ - Fino::Definition::Setting instance.
+  # +value+ - The deserialized global value.
+  # +overrides+ - Hash of scope overrides.
+  # +variants+ - Array of Fino::AbTesting::Variant instances.
   def write(setting_definition, value, overrides, variants)
     raise NotImplementedError
   end
 
+  # Returns an Array of String keys for all settings persisted in storage.
   def read_persisted_setting_keys
     raise NotImplementedError
   end
 
+  # Extracts the setting value from raw adapter data.
   def fetch_value_from(raw_adapter_data)
     raise NotImplementedError
   end
 
+  # Extracts raw override data from raw adapter data.
   def fetch_raw_overrides_from(raw_adapter_data)
     raise NotImplementedError
   end
 
+  # Extracts raw A/B variant data from raw adapter data.
   def fetch_raw_variants_from(raw_adapter_data)
     raise NotImplementedError
   end

--- a/lib/fino/cache.rb
+++ b/lib/fino/cache.rb
@@ -1,30 +1,69 @@
 # frozen_string_literal: true
 
+# Abstract interface for cache implementations.
+#
+# Caching is optional in Fino. When configured, the cache sits in the pipeline
+# between the library and the storage adapter, reducing round-trips for
+# frequently read settings.
+#
+# == Built-in Implementation
+#
+# - Fino::Cache::Memory -- process-local in-memory cache with TTL support
+#
+# == Implementing a Custom Cache
+#
+#   class MyCache
+#     include Fino::Cache
+#
+#     def read(key)    = @store[key]
+#     def write(key, value) = (@store[key] = value)
+#     def exist?(key)  = @store.key?(key)
+#     def delete(key)  = @store.delete(key)
+#     def clear        = @store.clear
+#
+#     def fetch(key, &block)
+#       exist?(key) ? read(key) : write(key, block.call)
+#     end
+#
+#     def fetch_multi(*keys, &block)
+#       # ...
+#     end
+#   end
 module Fino::Cache
+  # Returns +true+ if the key exists in the cache.
   def exist?(key)
     raise NotImplementedError
   end
 
+  # Returns the cached value for the key, or +nil+.
   def read(key)
     raise NotImplementedError
   end
 
+  # Stores a value in the cache under the given key.
   def write(key, value)
     raise NotImplementedError
   end
 
+  # Returns the cached value for the key, or calls the block, caches
+  # the result, and returns it.
   def fetch(key, &)
     raise NotImplementedError
   end
 
+  # Fetches multiple keys at once. Missing keys are resolved by calling
+  # the block with an Array of missing keys; the block should return a
+  # Hash of +{ key => value }+ pairs.
   def fetch_multi(*keys, &)
     raise NotImplementedError
   end
 
+  # Removes a single key from the cache.
   def delete(key)
     raise NotImplementedError
   end
 
+  # Removes all entries from the cache.
   def clear
     raise NotImplementedError
   end

--- a/lib/fino/cache/memory.rb
+++ b/lib/fino/cache/memory.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# Process-local in-memory cache with TTL-based expiration.
+#
+# Stores settings in a plain Hash and expires all entries once the TTL
+# elapses. Because this cache is not distributed, each process holds its
+# own copy; setting updates take effect after the TTL expires.
+#
+# == Usage
+#
+#   Fino.configure do
+#     cache { Fino::Cache::Memory.new(expires_in: 3) }
+#   end
+#
+# +expires_in+ - Numeric TTL in seconds. All entries are cleared when the
+#                TTL elapses.
 class Fino::Cache::Memory
   include Fino::Cache
 
@@ -8,22 +22,29 @@ class Fino::Cache::Memory
     @expirator = Fino::Expirator.new(ttl: expires_in) if expires_in
   end
 
+  # Returns +true+ if the key is present (checking expiration first).
   def exist?(key)
     expire_if_ready
 
     hash.key?(key)
   end
 
+  # Returns the cached value, or +nil+ (checking expiration first).
   def read(key)
     expire_if_ready
 
     hash[key]
   end
 
+  # Stores a value under the given key.
   def write(key, value)
     hash[key] = value
   end
 
+  # Returns the cached value for +key+, or calls the block, caches and
+  # returns the result.
+  #
+  # Raises +ArgumentError+ if no block is given.
   def fetch(key, &block)
     raise ArgumentError, "no block provided to #{self.class.name}#fetch" unless block
 
@@ -34,6 +55,10 @@ class Fino::Cache::Memory
     end
   end
 
+  # Fetches multiple keys. Missing keys are resolved by the block, which
+  # receives an Array of missing keys and should return a Hash of results.
+  #
+  # Raises +ArgumentError+ if no block is given.
   def fetch_multi(*keys, &block)
     raise ArgumentError, "no block provided to #{self.class.name}#fetch_multi" unless block
 
@@ -52,10 +77,12 @@ class Fino::Cache::Memory
     hash.values_at(*keys)
   end
 
+  # Removes a single key from the cache.
   def delete(key)
     hash.delete(key)
   end
 
+  # Clears all cached entries.
   def clear
     hash.clear
   end

--- a/lib/fino/configuration.rb
+++ b/lib/fino/configuration.rb
@@ -1,42 +1,117 @@
 # frozen_string_literal: true
 
+# Holds configuration for a Fino instance.
+#
+# Fino::Configuration is evaluated via the block passed to Fino.configure.
+# It provides a DSL for specifying the storage adapter, cache, pipeline
+# customizations, and setting definitions.
+#
+# == Example
+#
+#   Fino.configure do
+#     adapter { Fino::Redis::Adapter.new(Redis.new) }
+#     cache(if: -> { Rails.env.production? }) { Fino::Cache::Memory.new(expires_in: 3) }
+#
+#     wrap_adapter { |adapter| InstrumentedAdapter.new(adapter) }
+#     wrap_cache { |cache| InstrumentedCache.new(cache) }
+#
+#     pipeline { |p| p.use CustomPipe }
+#
+#     settings do
+#       setting :api_limit, :integer, default: 1000
+#       section :openai do
+#         setting :model, :string, default: "gpt-5"
+#       end
+#     end
+#   end
 class Fino::Configuration
-  attr_reader :registry, :pipeline_builder_block
+  # Returns the Fino::Registry holding setting and section definitions.
+  attr_reader :registry
+
+  # Returns the pipeline builder block, if one was configured via +pipeline+.
+  attr_reader :pipeline_builder_block
 
   def initialize(registry)
     @registry = registry
   end
 
+  # Returns the callable that builds the storage adapter.
+  #
+  # If +wrap_adapter+ was called, returns the wrapping proc; otherwise returns
+  # the block passed to +adapter+.
   def adapter_builder_block
     @wrapped_adapter_builder_block || @adapter_builder_block
   end
 
+  # Registers a block that builds the storage adapter.
+  #
+  # The block is called lazily when the adapter is first needed.
+  #
+  #   adapter { Fino::Redis::Adapter.new(redis) }
   def adapter(&block)
     @adapter_builder_block = block
   end
 
+  # Wraps the adapter built by +adapter+ with additional behavior.
+  #
+  # The block receives the original adapter instance and should return
+  # a wrapped adapter implementing the same Fino::Adapter interface.
+  #
+  #   wrap_adapter { |adapter| InstrumentedAdapter.new(adapter) }
   def wrap_adapter(&block)
     @wrapped_adapter_builder_block = proc { block.call(@adapter_builder_block.call) }
   end
 
+  # Returns the callable that builds the cache, or +nil+ if caching is
+  # disabled or the +if:+ condition returned false.
   def cache_builder_block
     @cache_builder_block && (@wrapped_cache_builder_block || @cache_builder_block)
   end
 
+  # Registers a block that builds the cache.
+  #
+  # The optional +if:+ parameter accepts a callable that determines whether
+  # caching should be enabled. When the callable returns false, the cache
+  # block is ignored.
+  #
+  #   cache { Fino::Cache::Memory.new(expires_in: 3.seconds) }
+  #   cache(if: -> { Rails.env.production? }) { Fino::Cache::Memory.new(expires_in: 5) }
   def cache(if: -> { true }, &block)
     return unless binding.local_variable_get(:if).call
 
     @cache_builder_block = block
   end
 
+  # Wraps the cache built by +cache+ with additional behavior.
+  #
+  # The block receives the original cache instance and should return
+  # a wrapped cache implementing the same Fino::Cache interface.
+  #
+  #   wrap_cache { |cache| InstrumentedCache.new(cache) }
   def wrap_cache(&block)
     @wrapped_cache_builder_block = proc { block.call(@cache_builder_block&.call) }
   end
 
+  # Registers a block for customizing the pipeline.
+  #
+  # The block receives the Fino::Pipeline instance and can add custom pipes.
+  #
+  #   pipeline { |p| p.use MyCustomPipe }
   def pipeline(&block)
     @pipeline_builder_block = block
   end
 
+  # Opens the settings definition DSL.
+  #
+  # The block is evaluated in the context of Fino::Registry::DSL, providing
+  # +setting+ and +section+ methods.
+  #
+  #   settings do
+  #     setting :timeout, :integer, default: 30
+  #     section :openai do
+  #       setting :model, :string, default: "gpt-5"
+  #     end
+  #   end
   def settings(&)
     Fino::Registry::DSL.new(registry).instance_eval(&)
   end

--- a/lib/fino/definition/section.rb
+++ b/lib/fino/definition/section.rb
@@ -1,22 +1,40 @@
 # frozen_string_literal: true
 
+# Describes a settings section (a named group of related settings).
+#
+# Sections are defined in the configuration DSL and stored in the
+# Fino::Registry. They provide logical grouping and a display label
+# for UI purposes.
+#
+#   section :openai, label: "OpenAI" do
+#     setting :model, :string, default: "gpt-5"
+#   end
 class Fino::Definition::Section
-  attr_reader :name, :options
+  # Returns the Symbol name of the section.
+  attr_reader :name
+
+  # Returns the Hash of additional options (e.g. +label:+).
+  attr_reader :options
 
   def initialize(name:, **options)
     @name = name
     @options = options
   end
 
+  # Returns the display label for this section.
+  #
+  # Falls back to the capitalized section name if no +:label+ option was provided.
   def label
     options.fetch(:label, name.to_s.capitalize)
   end
 
+  # Two sections are equal if they have the same class and name.
   def eql?(other)
     self.class.eql?(other.class) && name == other.name
   end
   alias == eql?
 
+  # Hash code based on the name, for use in Sets and Hash keys.
   def hash
     name.hash
   end

--- a/lib/fino/definition/setting.rb
+++ b/lib/fino/definition/setting.rb
@@ -1,6 +1,25 @@
 # frozen_string_literal: true
 
+# Describes a single setting: its name, type, section, and options.
+#
+# Setting definitions are created by the registry DSL and stored in the
+# Fino::Registry. They are used by the library to look up type classes,
+# default values, and storage keys.
+#
+# == Supported Types
+#
+# - +:string+  -- Fino::Settings::String
+# - +:integer+ -- Fino::Settings::Integer
+# - +:float+   -- Fino::Settings::Float
+# - +:boolean+ -- Fino::Settings::Boolean
+#
+# == Options
+#
+# - +default:+ -- Default value (deserialized via the type class)
+# - +description:+ -- Human-readable description
+# - +unit:+ -- Unit identifier for numeric types (+:ms+, +:sec+)
 class Fino::Definition::Setting
+  # All registered type classes.
   TYPE_CLASSES = [
     Fino::Settings::String,
     Fino::Settings::Integer,
@@ -8,11 +27,22 @@ class Fino::Definition::Setting
     Fino::Settings::Boolean
   ].freeze
 
+  # Maps Symbol type identifiers to their type classes.
   SETTING_TYPE_TO_TYPE_CLASS_MAPPING = TYPE_CLASSES.each_with_object({}) do |klass, hash|
     hash[klass.type_identifier] = klass
   end.freeze
 
-  attr_reader :setting_name, :section_definition, :type, :options
+  # Returns the Symbol name of this setting (e.g. +:model+).
+  attr_reader :setting_name
+
+  # Returns the Fino::Definition::Section this setting belongs to, or +nil+.
+  attr_reader :section_definition
+
+  # Returns the Symbol type identifier (+:string+, +:integer+, +:float+, +:boolean+).
+  attr_reader :type
+
+  # Returns the Hash of additional options (+default:+, +description:+, +unit:+, etc.).
+  attr_reader :options
 
   def initialize(type:, setting_name:, section_definition: nil, **options)
     @setting_name = setting_name
@@ -21,33 +51,42 @@ class Fino::Definition::Setting
     @options = options
   end
 
+  # Returns the setting type class (e.g. Fino::Settings::String).
+  #
+  # Raises +ArgumentError+ for unknown type identifiers.
   def type_class
     @type_class ||= SETTING_TYPE_TO_TYPE_CLASS_MAPPING.fetch(type) do
       raise ArgumentError, "Unknown setting type #{type}"
     end
   end
 
+  # Returns the deserialized default value, or +nil+ if none was provided.
   def default
     defined?(@default) ? @default : @default = type_class.deserialize(options[:default])
   end
 
+  # Returns the description string, or +nil+.
   def description
     defined?(@description) ? @description : @description = options[:description]
   end
 
+  # Returns the path components as an Array (e.g. +[:model, :openai]+).
   def path
     @path ||= [setting_name, section_definition&.name].compact
   end
 
+  # Returns the storage key string (e.g. +"openai/model"+).
   def key
     @key ||= path.reverse.join("/")
   end
 
+  # Two definitions are equal if they have the same class and key.
   def eql?(other)
     self.class.eql?(other.class) && key == other.key
   end
   alias == eql?
 
+  # Hash code based on the key, for use in Sets and Hash keys.
   def hash
     key.hash
   end

--- a/lib/fino/library.rb
+++ b/lib/fino/library.rb
@@ -2,6 +2,31 @@
 
 require "forwardable"
 
+# The core engine that handles all settings operations.
+#
+# Fino::Library reads and writes settings through a composable pipeline,
+# backed by a storage adapter and optional cache. It is the target of all
+# delegated methods on the Fino module.
+#
+# You typically interact with Library indirectly via +Fino.value+,
+# +Fino.set+, etc. Direct instantiation is only needed for advanced use
+# cases.
+#
+# == Reading settings
+#
+#   Fino.value(:model, at: :openai)
+#   Fino.values(:model, :temperature, at: :openai)
+#   Fino.setting(:model, at: :openai).overrides
+#
+# == Writing settings
+#
+#   Fino.set(model: "gpt-6", at: :openai)
+#   Fino.set(model: "gpt-5", at: :openai, overrides: { "qa" => "local" })
+#   Fino.set(model: "gpt-5", at: :openai, variants: { 20.0 => "gpt-6" })
+#
+# == Preloading
+#
+#   Fino.slice(:api_rate_limit, openai: [:model, :temperature])
 class Fino::Library
   include FeatureTogglesSupport
 
@@ -9,18 +34,70 @@ class Fino::Library
     @configuration = configuration
   end
 
+  # Returns the resolved value of a single setting.
+  #
+  # Supports scoped overrides and A/B variant resolution via the +for:+ context key.
+  # Numeric settings additionally accept a +unit:+ key for unit conversion.
+  #
+  #   Fino.value(:model, at: :openai)                  #=> "gpt-5"
+  #   Fino.value(:model, at: :openai, for: "qa")       #=> "local_model"
+  #   Fino.value(:timeout, at: :svc, unit: :sec)       #=> 0.2
+  #
+  # +setting_name+ - Symbol name of the setting.
+  # +at+ - Optional Symbol section name.
+  # +context+ - Optional keyword arguments passed to Setting#value
+  #             (+for:+ scope, +unit:+ conversion target).
+  #
+  # Returns the deserialized setting value.
   def value(setting_name, at: nil, **context)
     setting(setting_name, at: at).value(**context)
   end
 
+  # Returns an Array of resolved values for the given settings.
+  #
+  #   Fino.values(:model, :temperature, at: :openai) #=> ["gpt-5", 0.7]
+  #
+  # +setting_names+ - One or more Symbol setting names.
+  # +at+ - Optional Symbol section name applied to all settings.
+  # +context+ - Optional keyword arguments forwarded to each Setting#value.
+  #
+  # Returns an Array of deserialized values.
   def values(*setting_names, at: nil, **context)
     settings(*setting_names, at: at).map { |s| s.value(**context) }
   end
 
+  # Returns a single Fino::Setting object for the given setting.
+  #
+  # The Setting object exposes +value+, +overrides+, +experiment+,
+  # +default+, +description+, and other metadata.
+  #
+  #   setting = Fino.setting(:model, at: :openai)
+  #   setting.value           #=> "gpt-5"
+  #   setting.overrides       #=> { "qa" => "local_model" }
+  #   setting.ab_tested?      #=> true
+  #
+  # +setting_name+ - Symbol name of the setting.
+  # +at+ - Optional Symbol section name.
+  #
+  # Returns a Fino::Setting instance.
   def setting(setting_name, at: nil)
     pipeline.read(build_setting_definition(setting_name, at: at))
   end
 
+  # Returns an Array of Fino::Setting objects.
+  #
+  # When called with no arguments and no +at+, returns all registered settings.
+  # When +at+ is provided without names, returns all settings in that section.
+  # When names are provided, returns only the requested settings.
+  #
+  #   Fino.settings                                     #=> all settings
+  #   Fino.settings(at: :openai)                        #=> settings in openai section
+  #   Fino.settings(:model, :temperature, at: :openai)  #=> specific settings
+  #
+  # +setting_names+ - Zero or more Symbol setting names.
+  # +at+ - Optional Symbol section name.
+  #
+  # Returns an Array of Fino::Setting instances.
   def settings(*setting_names, at: Fino::EMPTINESS)
     setting_definitions =
       if setting_names.empty? && at.equal?(Fino::EMPTINESS)
@@ -36,6 +113,16 @@ class Fino::Library
     pipeline.read_multi(setting_definitions)
   end
 
+  # Adds scope overrides to an existing setting, merging with any overrides
+  # already present.
+  #
+  #   Fino.add_override(:model, at: :openai, "admin" => "gpt-2000")
+  #
+  # +setting_name+ - Symbol name of the setting.
+  # +at+ - Optional Symbol section name.
+  # +overrides+ - Keyword arguments mapping scope strings to raw values.
+  #
+  # Returns +true+.
   def add_override(setting_name, at: nil, **overrides)
     setting_definition = build_setting_definition(setting_name, at: at)
     current_setting = pipeline.read(setting_definition)
@@ -55,6 +142,22 @@ class Fino::Library
     true
   end
 
+  # Persists a setting value with optional scoped overrides and A/B testing variants.
+  #
+  # Accepts exactly one +setting_name: value+ pair as keyword arguments, plus
+  # optional +at:+, +overrides:+, and +variants:+ keys.
+  #
+  #   Fino.set(model: "gpt-6", at: :openai)
+  #   Fino.set(model: "gpt-5", at: :openai, overrides: { "qa" => "local" })
+  #   Fino.set(model: "gpt-5", at: :openai, variants: { 20.0 => "gpt-6" })
+  #
+  # +data+ - Keyword arguments containing:
+  #          * one +name: value+ pair for the setting
+  #          * +at:+ - optional Symbol section name
+  #          * +overrides:+ - optional Hash mapping scope strings to raw values
+  #          * +variants:+ - optional Hash mapping Float percentages to raw variant values
+  #
+  # Returns +true+.
   def set(**data)
     at = data.delete(:at)
     raw_overrides = data.delete(:overrides) || {}
@@ -85,6 +188,18 @@ class Fino::Library
     true
   end
 
+  # Preloads a specific subset of settings in a single adapter call.
+  #
+  # Accepts a mix of Symbol names (for top-level settings) and Hash entries
+  # (for sectioned settings).
+  #
+  #   Fino.slice(:api_rate_limit, openai: [:model, :temperature])
+  #
+  # +settings+ - Symbols or Hashes describing which settings to preload.
+  #
+  # Returns an Array of Fino::Setting instances.
+  #
+  # Raises +ArgumentError+ if an element is neither Symbol nor Hash.
   def slice(*settings)
     setting_definitions = settings.each_with_object([]) do |symbol_or_hash, memo|
       case symbol_or_hash
@@ -104,6 +219,7 @@ class Fino::Library
     pipeline.read_multi(setting_definitions)
   end
 
+  # Returns an Array of setting keys that have been persisted to the adapter.
   def persisted_keys
     adapter.read_persisted_setting_keys
   end

--- a/lib/fino/library/feature_toggles_support.rb
+++ b/lib/fino/library/feature_toggles_support.rb
@@ -1,6 +1,25 @@
 # frozen_string_literal: true
 
+# Mixin providing feature toggle convenience methods for Fino::Library.
+#
+# Adds +enabled?+, +disabled?+, +enable+, and +disable+ methods that
+# work exclusively with boolean settings. These methods raise +ArgumentError+
+# if called on a non-boolean setting.
+#
+#   Fino.enabled?(:maintenance_mode)            #=> false
+#   Fino.enable(:maintenance_mode, for: "qa")
+#   Fino.enabled?(:maintenance_mode, for: "qa") #=> true
 module Fino::Library::FeatureTogglesSupport
+  # Returns +true+ if the boolean setting is enabled.
+  #
+  #   Fino.enabled?(:new_ui, at: :feature_toggles)                  #=> true
+  #   Fino.enabled?(:new_ui, at: :feature_toggles, for: "beta")     #=> false
+  #
+  # +setting_name+ - Symbol name of a boolean setting.
+  # +at+ - Optional Symbol section name.
+  # +context+ - Optional keyword arguments (+for:+ scope).
+  #
+  # Raises +ArgumentError+ if the setting is not a boolean type.
   def enabled?(setting_name, at: nil, **context)
     setting = setting(setting_name, at: at)
     ensure_setting_is_boolean!(setting.definition)
@@ -8,6 +27,11 @@ module Fino::Library::FeatureTogglesSupport
     setting.enabled?(**context)
   end
 
+  # Returns +true+ if the boolean setting is disabled.
+  #
+  # Inverse of #enabled?. See #enabled? for parameter details.
+  #
+  # Raises +ArgumentError+ if the setting is not a boolean type.
   def disabled?(setting_name, at: nil, **context)
     setting = setting(setting_name, at: at)
     ensure_setting_is_boolean!(setting.definition)
@@ -15,6 +39,19 @@ module Fino::Library::FeatureTogglesSupport
     setting.disabled?(**context)
   end
 
+  # Enables a boolean setting globally or for a specific scope.
+  #
+  # When +for:+ is provided, adds a scoped override rather than changing the
+  # global value.
+  #
+  #   Fino.enable(:maintenance_mode)
+  #   Fino.enable(:maintenance_mode, for: "qa")
+  #
+  # +setting_name+ - Symbol name of a boolean setting.
+  # +at+ - Optional Symbol section name.
+  # +for+ - Optional scope identifier for a scoped override.
+  #
+  # Raises +ArgumentError+ if the setting is not a boolean type.
   def enable(setting_name, at: nil, for: nil)
     setting_definition = build_setting_definition(setting_name, at: at)
     ensure_setting_is_boolean!(setting_definition)
@@ -28,6 +65,19 @@ module Fino::Library::FeatureTogglesSupport
     end
   end
 
+  # Disables a boolean setting globally or for a specific scope.
+  #
+  # When +for:+ is provided, adds a scoped override rather than changing the
+  # global value.
+  #
+  #   Fino.disable(:maintenance_mode)
+  #   Fino.disable(:maintenance_mode, for: "qa")
+  #
+  # +setting_name+ - Symbol name of a boolean setting.
+  # +at+ - Optional Symbol section name.
+  # +for+ - Optional scope identifier for a scoped override.
+  #
+  # Raises +ArgumentError+ if the setting is not a boolean type.
   def disable(setting_name, at: nil, for: nil)
     setting_definition = build_setting_definition(setting_name, at: at)
     ensure_setting_is_boolean!(setting_definition)

--- a/lib/fino/metadata.rb
+++ b/lib/fino/metadata.rb
@@ -8,6 +8,7 @@ module Fino
   def metadata(spec)
     spec.metadata["source_code_uri"]       = spec.homepage
     spec.metadata["bug_tracker_uri"]       = "#{spec.homepage}/issues"
+    spec.metadata["documentation_uri"]     = "https://www.rubydoc.info/gems/fino"
     spec.metadata["rubygems_mfa_required"] = "true"
   end
 end

--- a/lib/fino/pipe.rb
+++ b/lib/fino/pipe.rb
@@ -1,18 +1,60 @@
 # frozen_string_literal: true
 
+# Abstract interface for pipeline pipes.
+#
+# A pipe wraps another pipe (or the base storage) and can intercept
+# +read+, +read_multi+, and +write+ operations. This enables composable
+# concerns like caching, instrumentation, or request-scoped storage.
+#
+# == Implementing a Custom Pipe
+#
+#   class MyPipe
+#     include Fino::Pipe
+#
+#     def read(setting_definition)
+#       # pre-processing
+#       result = pipe.read(setting_definition)
+#       # post-processing
+#       result
+#     end
+#
+#     def read_multi(setting_definitions)
+#       pipe.read_multi(setting_definitions)
+#     end
+#
+#     def write(setting_definition, value, overrides, variants)
+#       pipe.write(setting_definition, value, overrides, variants)
+#     end
+#   end
 module Fino::Pipe
   def initialize(pipe)
     @pipe = pipe
   end
 
+  # Reads a single setting through the pipeline.
+  #
+  # +setting_definition+ - A Fino::Definition::Setting instance.
+  #
+  # Returns a Fino::Setting instance.
   def read(setting_definition)
     raise NotImplementedError
   end
 
+  # Reads multiple settings through the pipeline.
+  #
+  # +setting_definitions+ - An Array of Fino::Definition::Setting instances.
+  #
+  # Returns an Array of Fino::Setting instances.
   def read_multi(setting_definitions)
     raise NotImplementedError
   end
 
+  # Writes a setting through the pipeline.
+  #
+  # +setting_definition+ - A Fino::Definition::Setting instance.
+  # +value+ - The deserialized value.
+  # +overrides+ - Hash of scope overrides.
+  # +variants+ - Array of Fino::AbTesting::Variant instances.
   def write(setting_definition, value, overrides, variants)
     raise NotImplementedError
   end

--- a/lib/fino/pipeline.rb
+++ b/lib/fino/pipeline.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# Composable pipeline for reading and writing settings.
+#
+# The pipeline wraps a base storage pipe with additional pipes (e.g. caching)
+# using the decorator pattern. Pipes are stacked in order: the last pipe added
+# is the outermost layer that handles requests first.
+#
+# == Usage
+#
+# Pipelines are built automatically by Fino::Library. Custom pipes can be
+# added via the configuration DSL:
+#
+#   Fino.configure do
+#     pipeline { |p| p.use MyCustomPipe, some_option }
+#   end
+#
+# == Custom Pipes
+#
+# A pipe must include Fino::Pipe and implement +read+, +read_multi+,
+# and +write+. Each pipe wraps the next pipe in the chain.
 class Fino::Pipeline
   extend Forwardable
 
@@ -10,6 +29,12 @@ class Fino::Pipeline
     @pipes = pipes
   end
 
+  # Adds a pipe to the pipeline.
+  #
+  # +pipe_class+ - A class that includes Fino::Pipe.
+  # Additional arguments are forwarded to the pipe constructor.
+  #
+  #   pipeline.use Fino::Pipe::Cache, cache_instance
   def use(pipe_class, ...)
     pipes << ->(pipe) { pipe_class.new(pipe, ...) }
     @pipeline = nil

--- a/lib/fino/registry.rb
+++ b/lib/fino/registry.rb
@@ -1,16 +1,41 @@
 # frozen_string_literal: true
 
+# Stores and indexes all setting and section definitions.
+#
+# The registry is populated during Fino.configure via the DSL and provides
+# lookup methods used by Fino::Library to resolve setting names to their
+# definitions.
 class Fino::Registry
+  # Raised when attempting to register a setting that already exists at the
+  # same path.
   DuplicateSetting = Class.new(Fino::Error)
+
+  # Raised when looking up a setting that has not been registered.
   UnknownSetting = Class.new(Fino::Error)
 
+  # DSL for defining settings and sections within a Fino.configure block.
+  #
+  #   Fino.configure do
+  #     settings do
+  #       setting :timeout, :integer, default: 30
+  #       section :openai, label: "OpenAI" do
+  #         setting :model, :string, default: "gpt-5"
+  #       end
+  #     end
+  #   end
   class DSL
+    # DSL context for defining settings within a section.
     class SectionDSL
       def initialize(section_definition, registry)
         @section_definition = section_definition
         @registry = registry
       end
 
+      # Defines a setting within the current section.
+      #
+      # +setting_name+ - Symbol name of the setting.
+      # +type+ - Symbol type identifier (+:string+, +:integer+, +:float+, or +:boolean+).
+      # +options+ - Additional keyword arguments (+default:+, +description:+, +unit:+).
       def setting(setting_name, type, **)
         @registry.register(
           Fino::Definition::Setting.new(
@@ -27,6 +52,13 @@ class Fino::Registry
       @registry = registry
     end
 
+    # Defines a top-level setting (not scoped to a section).
+    #
+    # +setting_name+ - Symbol name of the setting.
+    # +type+ - Symbol type identifier (+:string+, +:integer+, +:float+, or +:boolean+).
+    # +options+ - Additional keyword arguments (+default:+, +description:+, +unit:+).
+    #
+    #   setting :api_rate_limit, :integer, default: 1000, description: "Max requests/min"
     def setting(setting_name, type, **)
       @registry.register(
         Fino::Definition::Setting.new(
@@ -37,6 +69,16 @@ class Fino::Registry
       )
     end
 
+    # Defines a section that groups related settings.
+    #
+    # +section_name+ - Symbol name of the section.
+    # +options+ - Optional hash with +:label+ for display purposes.
+    #
+    # The block is evaluated in the context of SectionDSL.
+    #
+    #   section :openai, label: "OpenAI" do
+    #     setting :model, :string, default: "gpt-5"
+    #   end
     def section(section_name, options = {}, &)
       section_definition = Fino::Definition::Section.new(
         name: section_name,
@@ -51,7 +93,11 @@ class Fino::Registry
 
   using Fino::Ext::Hash
 
-  attr_reader :setting_definitions, :section_definitions
+  # Returns the Set of all registered Fino::Definition::Setting instances.
+  attr_reader :setting_definitions
+
+  # Returns the Set of all registered Fino::Definition::Section instances.
+  attr_reader :section_definitions
 
   def initialize
     @setting_definitions = Set.new
@@ -61,16 +107,29 @@ class Fino::Registry
     @section_definitions_by_name = {}
   end
 
+  # Looks up a setting definition by path components.
+  #
+  # +path+ - One or two arguments: +setting_name+ or +setting_name, section_name+.
+  #          Nil components are stripped.
+  #
+  # Returns the Fino::Definition::Setting, or +nil+ if not found.
   def setting_definition(*path)
     @setting_definitions_by_path.dig(*path.compact.reverse.map(&:to_s))
   end
 
+  # Same as #setting_definition but raises Fino::Registry::UnknownSetting
+  # when the definition is not found.
   def setting_definition!(*path)
     setting_definition(*path).tap do |definition|
       raise UnknownSetting, "Unknown setting: #{path.compact.join('.')}" unless definition
     end
   end
 
+  # Returns setting definitions, optionally filtered by section.
+  #
+  # When called with no arguments, returns all definitions.
+  # When +at:+ is +nil+, returns only unsectioned (top-level) settings.
+  # When +at:+ is a section name, returns settings in that section.
   def setting_definitions(at: Fino::EMPTINESS)
     case at
     when Fino::EMPTINESS
@@ -82,10 +141,14 @@ class Fino::Registry
     end
   end
 
+  # Returns the Fino::Definition::Section for the given name, or +nil+.
   def section_definition(section_name)
     @section_definitions_by_name[section_name.to_s]
   end
 
+  # Registers a new setting definition.
+  #
+  # Raises DuplicateSetting if a setting with the same key is already registered.
   def register(setting_definition)
     unless @setting_definitions.add?(setting_definition)
       raise DuplicateSetting, "#{setting_definition.setting_name} is already registered at #{setting_definition.key}"
@@ -94,6 +157,7 @@ class Fino::Registry
     @setting_definitions_by_path.deep_set(setting_definition, *setting_definition.path.map(&:to_s))
   end
 
+  # Registers a new section definition. Silently ignores duplicates.
   def register_section(section_definition)
     return unless @section_definitions.add?(section_definition)
 

--- a/lib/fino/setting.rb
+++ b/lib/fino/setting.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
+# Base module included by all setting type classes (String, Integer, Float, Boolean).
+#
+# Provides the common interface for setting instances: value resolution with
+# scope overrides and A/B testing, plus metadata accessors delegated to the
+# underlying Fino::Definition::Setting.
+#
+# == Value Resolution Order
+#
+# When +value(for: scope)+ is called:
+# 1. Check scoped overrides for a match
+# 2. Check A/B testing experiment for a variant assignment
+# 3. Fall back to the global value
+#
+# == Class Methods (via ClassMethods)
+#
+# Each type class must implement +serialize+ and +deserialize+ for converting
+# between Ruby objects and storage-friendly string representations.
 module Fino::Setting
   include Fino::PrettyInspectable
 
@@ -7,25 +24,44 @@ module Fino::Setting
     base.extend(ClassMethods)
   end
 
+  # Class-level methods extended onto setting type classes.
   module ClassMethods
+    # Sets the Symbol identifier for this type (e.g. +:string+, +:integer+).
     def type_identifier=(identifier)
       @type_identifier = identifier
     end
 
+    # Returns the Symbol type identifier for this setting type.
     def type_identifier
       @type_identifier
     end
 
+    # Converts a Ruby value to a string for storage.
+    #
+    # Must be implemented by each type class.
     def serialize(value)
       raise NotImplementedError
     end
 
+    # Converts a raw storage value back to the appropriate Ruby type.
+    #
+    # Must be implemented by each type class.
     def deserialize(raw_value)
       raise NotImplementedError
     end
   end
 
-  attr_reader :definition, :global_value, :overrides, :experiment
+  # Returns the Fino::Definition::Setting that describes this setting.
+  attr_reader :definition
+
+  # Returns the global (default/persisted) value, before any scope resolution.
+  attr_reader :global_value
+
+  # Returns a Hash of scope overrides (+{ "scope_name" => value }+).
+  attr_reader :overrides
+
+  # Returns the Fino::AbTesting::Experiment for this setting, or +nil+.
+  attr_reader :experiment
 
   def initialize(definition, global_value, overrides = {}, experiment = nil)
     @definition = definition
@@ -34,6 +70,14 @@ module Fino::Setting
     @experiment = experiment
   end
 
+  # Returns the resolved value for this setting.
+  #
+  # Without a +for:+ context key, returns the global value. With +for:+,
+  # checks overrides first, then A/B experiment variants, falling back to
+  # the global value.
+  #
+  #   setting.value                  #=> "gpt-5"
+  #   setting.value(for: "qa")       #=> "local_model"
   def value(**context)
     return global_value unless (scope = context[:for])
 
@@ -47,42 +91,52 @@ module Fino::Setting
     end
   end
 
+  # Returns the Symbol name of this setting.
   def name
     definition.setting_name
   end
 
+  # Returns the storage key string (e.g. +"openai/model"+).
   def key
     definition.key
   end
 
+  # Returns the Symbol type identifier (e.g. +:string+, +:integer+).
   def type
     definition.type
   end
 
+  # Returns the type class (e.g. Fino::Settings::String).
   def type_class
     definition.type_class
   end
 
+  # Returns the Fino::Definition::Section this setting belongs to, or +nil+.
   def section_definition
     definition.section_definition
   end
 
+  # Returns the Symbol section name, or +nil+ for top-level settings.
   def section_name
     definition.section_definition&.name
   end
 
+  # Returns the default value for this setting (deserialized).
   def default
     definition.default
   end
 
+  # Returns the description string, or +nil+.
   def description
     definition.description
   end
 
+  # Returns +true+ if this setting has any scoped overrides.
   def overriden?
     !overrides.empty?
   end
 
+  # Returns +true+ if this setting has an A/B testing experiment attached.
   def ab_tested?
     !!experiment
   end

--- a/lib/fino/settings/boolean.rb
+++ b/lib/fino/settings/boolean.rb
@@ -1,15 +1,30 @@
 # frozen_string_literal: true
 
+# Boolean setting type, used for feature toggles and on/off flags.
+#
+# Serializes to +"1"+ / +"0"+ and deserializes a range of truthy representations
+# (+"1"+, +1+, +true+, +"true"+, +"t"+, +"yes"+, +"y"+).
+#
+# Provides +enabled?+ and +disabled?+ convenience methods.
+#
+# Registered as +:boolean+ in the settings DSL.
+#
+#   setting :maintenance_mode, :boolean, default: false
 class Fino::Settings::Boolean
   include Fino::Setting
 
   self.type_identifier = :boolean
 
   class << self
+    # Serializes a boolean to +"1"+ (true) or +"0"+ (false).
     def serialize(value)
       value ? "1" : "0"
     end
 
+    # Deserializes a raw value to +true+ or +false+.
+    #
+    # Truthy values: +"1"+, +1+, +true+, +"true"+, +"t"+, +"yes"+, +"y"+.
+    # Everything else is +false+.
     def deserialize(raw_value)
       case raw_value
       when "1", 1, true, "true", "t", "yes", "y" then true
@@ -18,10 +33,15 @@ class Fino::Settings::Boolean
     end
   end
 
+  # Returns +true+ if the setting value is truthy for the given context.
+  #
+  #   setting.enabled?                #=> true
+  #   setting.enabled?(for: "beta")   #=> false
   def enabled?(**context)
     value(**context)
   end
 
+  # Returns +true+ if the setting value is falsy for the given context.
   def disabled?(**context)
     !enabled?(**context)
   end

--- a/lib/fino/settings/float.rb
+++ b/lib/fino/settings/float.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+# Float setting type. Values are stored as strings and parsed via +to_f+.
+#
+# Includes Fino::Settings::Numeric for unit conversion support.
+#
+# Registered as +:float+ in the settings DSL.
+#
+#   setting :temperature, :float, default: 0.7
 class Fino::Settings::Float
   include Fino::Setting
   include Fino::Settings::Numeric
@@ -7,10 +14,12 @@ class Fino::Settings::Float
   self.type_identifier = :float
 
   class << self
+    # Converts a Float to a String for storage.
     def serialize(value)
       value.to_s
     end
 
+    # Parses a stored string back to a Float.
     def deserialize(raw_value)
       raw_value.to_f
     end

--- a/lib/fino/settings/integer.rb
+++ b/lib/fino/settings/integer.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
+# Integer setting type. Values are stored as strings and parsed via +to_i+.
+#
+# Includes Fino::Settings::Numeric for unit conversion support.
+#
+# Registered as +:integer+ in the settings DSL.
+#
+#   setting :api_rate_limit, :integer, default: 1000
+#   setting :timeout, :integer, unit: :ms, default: 200
 class Fino::Settings::Integer
   include Fino::Setting
   include Fino::Settings::Numeric
@@ -7,10 +15,12 @@ class Fino::Settings::Integer
   self.type_identifier = :integer
 
   class << self
+    # Converts an Integer to a String for storage.
     def serialize(value)
       value.to_s
     end
 
+    # Parses a stored string back to an Integer.
     def deserialize(raw_value)
       raw_value.to_i
     end

--- a/lib/fino/settings/numeric.rb
+++ b/lib/fino/settings/numeric.rb
@@ -1,32 +1,66 @@
 # frozen_string_literal: true
 
+# Mixin for numeric setting types (Integer, Float) that adds unit conversion.
+#
+# When a setting is defined with a +unit:+ option, its value can be converted
+# to a different compatible unit at read time via the +unit:+ context key.
+#
+# == Supported Units
+#
+# Time units are interconvertible:
+# - +:ms+ / +:milliseconds+ -- Fino::Settings::Numeric::Unit::Milliseconds
+# - +:sec+ / +:seconds+ -- Fino::Settings::Numeric::Unit::Seconds
+#
+# == Example
+#
+#   # Define with unit
+#   setting :http_read_timeout, :integer, unit: :ms, default: 200
+#
+#   # Read in different unit
+#   Fino.value(:http_read_timeout, at: :svc)              #=> 200
+#   Fino.value(:http_read_timeout, at: :svc, unit: :sec)  #=> 0.2
 module Fino::Settings::Numeric
+  # Namespace for unit types used in numeric setting conversion.
   module Unit
+    # Base class for all unit types.
+    #
+    # Custom units can subclass Generic and override +base_factor+ and
+    # +convertible_to?+ to enable conversions.
     class Generic
-      attr_reader :name, :short_name
+      # Returns the full name of the unit (e.g. "Milliseconds").
+      attr_reader :name
+
+      # Returns the abbreviated name (e.g. "ms").
+      attr_reader :short_name
 
       def initialize(name, short_name = nil)
         @name = name
         @short_name = short_name || name
       end
 
+      # Returns the factor to convert this unit to the base unit.
       def base_factor
         1
       end
 
+      # Returns +false+ by default. Override in subclasses to enable conversion.
       def convertible_to?(_other)
         false
       end
     end
 
+    # Mixin for time-based units, enabling conversion between them.
     module Time
+      # The base unit for time conversions.
       BASE_UNIT = :seconds
 
+      # Returns +true+ if the other unit also includes Time.
       def convertible_to?(other)
         other.is_a?(Time)
       end
     end
 
+    # Milliseconds time unit. Base factor: 0.001 (relative to seconds).
     class Milliseconds < Generic
       include Time
 
@@ -37,6 +71,7 @@ module Fino::Settings::Numeric
       end
     end
 
+    # Seconds time unit. Base factor: 1 (the base time unit).
     class Seconds < Generic
       include Time
 
@@ -49,6 +84,11 @@ module Fino::Settings::Numeric
 
     module_function
 
+    # Returns a Unit instance for the given identifier.
+    #
+    # +identifier+ - Symbol or String (+:ms+, +:sec+, +:milliseconds+, +:seconds+).
+    #
+    # Unrecognized identifiers return a Generic unit (not convertible).
     def for(identifier)
       case identifier.to_s
       when "ms", "milliseconds"
@@ -61,6 +101,15 @@ module Fino::Settings::Numeric
     end
   end
 
+  # Returns the resolved value, optionally converted to a target unit.
+  #
+  # Pass +unit:+ in the context to request unit conversion.
+  #
+  #   setting.value                 #=> 200
+  #   setting.value(unit: :sec)     #=> 0.2
+  #
+  # Raises +ArgumentError+ if no unit is defined on the setting or the
+  # units are not convertible.
   def value(**context)
     result = super
     return result unless (target_unit_identifier = context[:unit])
@@ -73,6 +122,7 @@ module Fino::Settings::Numeric
     result * unit.base_factor / target_unit.base_factor
   end
 
+  # Returns the Unit instance for this setting, or +nil+ if no unit is defined.
   def unit
     return unless (identifier = definition.options[:unit])
 

--- a/lib/fino/settings/string.rb
+++ b/lib/fino/settings/string.rb
@@ -1,15 +1,22 @@
 # frozen_string_literal: true
 
+# String setting type. Values are stored and returned as-is.
+#
+# Registered as +:string+ in the settings DSL.
+#
+#   setting :model, :string, default: "gpt-5"
 class Fino::Settings::String
   include Fino::Setting
 
   self.type_identifier = :string
 
   class << self
+    # Returns the value unchanged (strings need no conversion).
     def serialize(value)
       value
     end
 
+    # Returns the raw value unchanged.
     def deserialize(raw_value)
       raw_value
     end


### PR DESCRIPTION
This PR adds extensive YARD-style documentation to all public APIs across the Fino codebase, making the library more discoverable and easier to use.

## Summary

Added detailed documentation comments to all public classes, modules, and methods throughout the Fino library. This includes usage examples, parameter descriptions, return value documentation, and architectural overviews for key components.

## Key Changes

- **Core modules and classes**: Added module-level documentation to `Fino`, `Fino::Library`, `Fino::Configuration`, `Fino::Registry`, and all setting type classes
- **Public methods**: Documented all public methods with parameter descriptions, return types, and usage examples
- **Architecture documentation**: Added high-level overviews explaining how components interact (e.g., pipeline architecture, value resolution order, A/B testing)
- **DSL documentation**: Documented the configuration DSL with examples showing how to define settings and sections
- **Interface documentation**: Added documentation to abstract interfaces (`Fino::Adapter`, `Fino::Pipe`, `Fino::Cache`) with implementation guidance
- **RDoc configuration**: Added `Rakefile` task and `.rdoc_options` file to generate HTML documentation
- **Metadata**: Updated gem metadata to include documentation URI pointing to rubydoc.info

## Notable Details

- Documentation includes practical examples for common use cases (reading/writing settings, scoped overrides, A/B testing, unit conversion)
- Abstract interfaces include "Implementing a Custom" sections to guide extension
- Setting type classes document their serialization behavior and supported options
- Feature toggle methods are documented with examples showing scope-based overrides
- All documentation follows YARD conventions for compatibility with standard Ruby documentation tools

https://claude.ai/code/session_01JX39YHeWvyVEuUQbogtSqm